### PR TITLE
Components - better icon prop usage

### DIFF
--- a/src/components/BenefitCard/BenefitCard.tsx
+++ b/src/components/BenefitCard/BenefitCard.tsx
@@ -5,11 +5,12 @@ export default function BenefitCard({
   description,
   icon,
 }: BenefitCardProps) {
+  const props = { icon };
   return (
     <article>
       <div className="px-6 py-4 rounded flex flex-col bg-secondary/40">
         <div className="text-primary/90 dark:text-primarydark/90 flex justify-center">
-          {icon}
+          <props.icon size={64} stroke={1.5} />
         </div>
         <h2 className="text-primary dark:text-primarydark text-center text-lg font-semibold">
           {title}

--- a/src/components/BenefitCard/benefitcard.d.ts
+++ b/src/components/BenefitCard/benefitcard.d.ts
@@ -1,7 +1,7 @@
-import { ReactElement } from "react";
+import { TablerIcon } from "@tabler/icons-react";
 
 export type BenefitCardProps = {
   title: string;
   description: string;
-  icon: ReactElement;
+  icon: TablerIcon;
 };

--- a/src/components/BenefitCard/benefitcard.test.tsx
+++ b/src/components/BenefitCard/benefitcard.test.tsx
@@ -17,7 +17,7 @@ describe("BenefitCard", () => {
       <BenefitCard
         title={title}
         description={description}
-        icon={<IconCalendarTime stroke={1.5} size={64} />}
+        icon={IconCalendarTime}
       />,
     );
   });

--- a/src/components/BenefitList/BenefitList.tsx
+++ b/src/components/BenefitList/BenefitList.tsx
@@ -19,28 +19,28 @@ export default function BenefitList() {
           <BenefitCard
             title={t("benefitList.delivery.title")}
             description={t("benefitList.delivery.description")}
-            icon={<IconSteeringWheel stroke={1.5} size={64} />}
+            icon={IconSteeringWheel}
           />
         </li>
         <li>
           <BenefitCard
             title={t("benefitList.guarantee.title")}
             description={t("benefitList.guarantee.description")}
-            icon={<IconHeartHandshake stroke={1.5} size={64} />}
+            icon={IconHeartHandshake}
           />
         </li>
         <li>
           <BenefitCard
             title={t("benefitList.financing.title")}
             description={t("benefitList.financing.description")}
-            icon={<IconPigMoney stroke={1.5} size={64} />}
+            icon={IconPigMoney}
           />
         </li>
         <li>
           <BenefitCard
             title={t("benefitList.community.title")}
             description={t("benefitList.community.description")}
-            icon={<IconUsersGroup stroke={1.5} size={64} />}
+            icon={IconUsersGroup}
           />
         </li>
       </ul>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -54,6 +54,19 @@ export default function Button({
     }
   }, []);
 
+  const iconSize = useMemo(() => {
+    switch (size) {
+      case "xs":
+        return 14;
+      case "sm":
+        return 14;
+      case "lg":
+        return 18;
+      default:
+        return 16;
+    }
+  }, []);
+
   const colorClassname = useMemo(() => {
     switch (color) {
       case "primary":
@@ -62,6 +75,11 @@ export default function Button({
         return "bg-secondary text-black dark:bg-secondarydark dark:text-white";
     }
   }, []);
+
+  const icons = {
+    start: startIcon,
+    end: endIcon,
+  };
 
   return (
     <button
@@ -77,9 +95,9 @@ export default function Button({
         className,
       )}
     >
-      {startIcon && <div className={textSizeClassname}>{startIcon}</div>}
+      {!!icons.start && <icons.start size={iconSize} />}
       <span className={clsx("flex-1", textSizeClassname)}>{children}</span>
-      {endIcon && <div className={textSizeClassname}>{endIcon}</div>}
+      {!!icons.end && <icons.end size={iconSize} />}
     </button>
   );
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,6 +13,7 @@ export default function Button({
   size,
   color,
   rounded,
+  expanded,
 }: ButtonProps) {
   const roundedClassname = useMemo(() => {
     if (!rounded) return "";
@@ -89,6 +90,10 @@ export default function Button({
       disabled={isDisabled}
       className={clsx(
         "inline-flex items-center h-fit hover:opacity-90 leading-none",
+        {
+          "w-fit": !expanded,
+          "w-full": expanded,
+        },
         containerClassname,
         colorClassname,
         roundedClassname,

--- a/src/components/Button/button.d.ts
+++ b/src/components/Button/button.d.ts
@@ -1,9 +1,9 @@
-import { ReactElement } from "react";
+import { TablerIcon } from "@tabler/icons-react";
 
 export type ButtonProps = {
   className?: string;
-  startIcon?: ReactElement;
-  endIcon?: ReactElement;
+  startIcon?: TablerIcon;
+  endIcon?: TablerIcon;
   children: string;
   size?: "xs" | "sm" | "lg";
   color?: "primary" | "secondary";

--- a/src/components/Button/button.d.ts
+++ b/src/components/Button/button.d.ts
@@ -9,4 +9,5 @@ export type ButtonProps = {
   color?: "primary" | "secondary";
   rounded?: boolean;
   isDisabled?: boolean;
+  expanded?: boolean;
 };

--- a/src/components/Button/button.test.tsx
+++ b/src/components/Button/button.test.tsx
@@ -31,20 +31,20 @@ describe("Button", () => {
   });
 
   it("Renders a start icon if provided from props", () => {
-    render(<Button startIcon={<IconArrowLeft />}>{text}</Button>);
+    render(<Button startIcon={IconArrowLeft}>{text}</Button>);
     const startIcon = document.querySelector(".tabler-icon");
     expect(startIcon).toBeInTheDocument();
   });
 
   it("Renders a end icon if provided from props", () => {
-    render(<Button endIcon={<IconArrowRight />}>{text}</Button>);
+    render(<Button endIcon={IconArrowRight}>{text}</Button>);
     const endIcon = document.querySelector(".tabler-icon");
     expect(endIcon).toBeInTheDocument();
   });
 
   it("Renders both start and end icon if provided from props", () => {
     render(
-      <Button startIcon={<IconArrowLeft />} endIcon={<IconArrowRight />}>
+      <Button startIcon={IconArrowLeft} endIcon={IconArrowRight}>
         {text}
       </Button>,
     );

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -31,32 +31,36 @@ const ChipIcon = ({ className, children, href }: ChipIconProps) => {
 
 export default function Chip({
   children,
-  leftIcon,
-  rightIcon,
+  startIcon,
+  endIcon,
   iconHref,
 }: ChipProps) {
+  const icons = {
+    start: startIcon,
+    end: endIcon,
+  };
   return (
     <div
       data-testid="chip"
       className="inline-flex rounded bg-primary dark:bg-primarydark"
     >
-      {!!leftIcon && (
+      {!!icons.start && (
         <ChipIcon className="pr-1 pl-2" href={iconHref}>
-          {leftIcon}
+          <icons.start />
         </ChipIcon>
       )}
       <span
         className={clsx("text-white text-xs py-1 font-medium dark:text-black", {
-          "pr-2": !!leftIcon,
-          "pl-2": !!rightIcon,
-          "px-1.5": !rightIcon && !leftIcon,
+          "pr-2": !!icons.start,
+          "pl-2": !!icons.end,
+          "px-1.5": !icons.end && !icons.start,
         })}
       >
         {children}
       </span>
-      {!!rightIcon && (
+      {!!icons.end && (
         <ChipIcon className="pl-1 pr-2" href={iconHref}>
-          {rightIcon}
+          <icons.end />
         </ChipIcon>
       )}
     </div>

--- a/src/components/Chip/chip.d.ts
+++ b/src/components/Chip/chip.d.ts
@@ -1,12 +1,14 @@
 import { ReactNode } from "react";
 
+import { TablerIcon } from "@tabler/icons-react";
+
 import type { Url } from "@/types";
 
 export type ChipProps = {
   className?: string;
   children: string;
-  leftIcon?: ReactNode;
-  rightIcon?: ReactNode;
+  startIcon?: TablerIcon;
+  endIcon?: TablerIcon;
   /** If passed, the path is set to a Link element */
   iconHref?: Url;
 };

--- a/src/components/Chip/chip.test.tsx
+++ b/src/components/Chip/chip.test.tsx
@@ -22,21 +22,21 @@ describe("Chip", () => {
     expect(span).toBeInTheDocument();
   });
 
-  it("Renders a left icon if provided from props", () => {
-    render(<Chip leftIcon={<IconX />}>{text}</Chip>);
-    const leftIcon = document.querySelector(".tabler-icon");
-    expect(leftIcon).toBeInTheDocument();
+  it("Renders a start icon if provided from props", () => {
+    render(<Chip startIcon={IconX}>{text}</Chip>);
+    const startIcon = document.querySelector(".tabler-icon");
+    expect(startIcon).toBeInTheDocument();
   });
 
-  it("Renders a right icon if provided from props", () => {
-    render(<Chip rightIcon={<IconX />}>{text}</Chip>);
-    const rightIcon = document.querySelector(".tabler-icon");
-    expect(rightIcon).toBeInTheDocument();
+  it("Renders a end icon if provided from props", () => {
+    render(<Chip endIcon={IconX}>{text}</Chip>);
+    const endIcon = document.querySelector(".tabler-icon");
+    expect(endIcon).toBeInTheDocument();
   });
 
   it("Renders a link for icons when passing href prop", () => {
     render(
-      <Chip rightIcon={<IconX />} iconHref={href}>
+      <Chip endIcon={IconX} iconHref={href}>
         {text}
       </Chip>,
     );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -65,7 +65,7 @@ export default function Header() {
           className="text-white block md:hidden"
           size="sm"
         >
-          <IconMenu2 size={20} stroke={2} />
+          {IconMenu2}
         </IconButton>
 
         <HeaderSideDrawer

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -63,7 +63,7 @@ export default function Header() {
         <IconButton
           onClick={handleOpenSideDrawer}
           className="text-white block md:hidden"
-          size="sm"
+          size="lg"
         >
           {IconMenu2}
         </IconButton>

--- a/src/components/HeaderSideDrawer/HeaderSideDrawer.tsx
+++ b/src/components/HeaderSideDrawer/HeaderSideDrawer.tsx
@@ -14,11 +14,7 @@ import {
 import HeaderSideDrawerListItem from "@/components/HeaderSideDrawerListItem";
 import SideDrawer from "@/components/SideDrawer";
 
-import {
-  HEADER_SIDE_DRAWER_LIST_ITEM_ICON_SIZE,
-  HEADER_SIDE_DRAWER_LIST_ITEM_ICON_STROKE,
-  type HeaderSideDrawerProps,
-} from ".";
+import type { HeaderSideDrawerProps } from ".";
 
 export default function HeaderSideDrawer({
   isOpen,
@@ -30,73 +26,39 @@ export default function HeaderSideDrawer({
     <SideDrawer isOpen={isOpen} onClose={onClose}>
       <nav className="flex flex-col justify-between flex-1">
         <ul className="flex flex-col">
-          <HeaderSideDrawerListItem
-            icon={
-              <IconHome
-                size={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_SIZE}
-                stroke={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_STROKE}
-              />
-            }
-            href="/"
-            onClick={onClose}
-          >
+          <HeaderSideDrawerListItem icon={IconHome} href="/" onClick={onClose}>
             {t("navigation.home")}
           </HeaderSideDrawerListItem>
           <HeaderSideDrawerListItem
-            icon={
-              <IconCar
-                size={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_SIZE}
-                stroke={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_STROKE}
-              />
-            }
+            icon={IconCar}
             href="/vehicles"
             onClick={onClose}
           >
             {t("navigation.usedVehicles.title")}
           </HeaderSideDrawerListItem>
           <HeaderSideDrawerListItem
-            icon={
-              <IconWheel
-                size={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_SIZE}
-                stroke={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_STROKE}
-              />
-            }
+            icon={IconWheel}
             href="/wheels"
             onClick={onClose}
           >
             {t("navigation.rimsTires.title")}
           </HeaderSideDrawerListItem>
           <HeaderSideDrawerListItem
-            icon={
-              <IconBriefcase
-                size={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_SIZE}
-                stroke={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_STROKE}
-              />
-            }
+            icon={IconBriefcase}
             href="#"
             onClick={onClose}
           >
             {t("navigation.careers.title")}
           </HeaderSideDrawerListItem>
           <HeaderSideDrawerListItem
-            icon={
-              <IconLifebuoy
-                size={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_SIZE}
-                stroke={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_STROKE}
-              />
-            }
+            icon={IconLifebuoy}
             href="#"
             onClick={onClose}
           >
             {t("navigation.helpCenter.title")}
           </HeaderSideDrawerListItem>
           <HeaderSideDrawerListItem
-            icon={
-              <IconInfoCircle
-                size={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_SIZE}
-                stroke={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_STROKE}
-              />
-            }
+            icon={IconInfoCircle}
             href="#"
             onClick={onClose}
           >
@@ -106,27 +68,13 @@ export default function HeaderSideDrawer({
 
         <ul>
           <HeaderSideDrawerListItem
-            icon={
-              <IconShoppingCart
-                size={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_SIZE}
-                stroke={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_STROKE}
-              />
-            }
+            icon={IconShoppingCart}
             href="#"
             onClick={onClose}
           >
             {t("header.myCart")}
           </HeaderSideDrawerListItem>
-          <HeaderSideDrawerListItem
-            icon={
-              <IconUser
-                size={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_SIZE}
-                stroke={HEADER_SIDE_DRAWER_LIST_ITEM_ICON_STROKE}
-              />
-            }
-            href="#"
-            onClick={onClose}
-          >
+          <HeaderSideDrawerListItem icon={IconUser} href="#" onClick={onClose}>
             {t("header.account")}
           </HeaderSideDrawerListItem>
         </ul>

--- a/src/components/HeaderSideDrawerListItem/HeaderSideDrawerListItem.tsx
+++ b/src/components/HeaderSideDrawerListItem/HeaderSideDrawerListItem.tsx
@@ -12,7 +12,7 @@ export default function HeaderSideDrawerListItem({
   return (
     <li className="border-b border-b-divider last-of-type:border-b-transparent px-2 py-3">
       <Link onClick={onClick} className="flex items-center gap-3" href={href}>
-        <props.icon />
+        <props.icon size={16} />
         <h3 className="text-sm">{children}</h3>
       </Link>
     </li>

--- a/src/components/HeaderSideDrawerListItem/HeaderSideDrawerListItem.tsx
+++ b/src/components/HeaderSideDrawerListItem/HeaderSideDrawerListItem.tsx
@@ -8,10 +8,11 @@ export default function HeaderSideDrawerListItem({
   children,
   onClick,
 }: HeaderSideDrawerListItemProps) {
+  const props = { icon };
   return (
     <li className="border-b border-b-divider last-of-type:border-b-transparent px-2 py-3">
       <Link onClick={onClick} className="flex items-center gap-3" href={href}>
-        {icon}
+        <props.icon />
         <h3 className="text-sm">{children}</h3>
       </Link>
     </li>

--- a/src/components/HeaderSideDrawerListItem/headersidedrawerlistitem.d.ts
+++ b/src/components/HeaderSideDrawerListItem/headersidedrawerlistitem.d.ts
@@ -1,7 +1,7 @@
-import { ReactElement } from "react";
+import { TablerIcon } from "@tabler/icons-react";
 
 export type HeaderSideDrawerListItemProps = {
-  icon: ReactElement;
+  icon: TablerIcon;
   href: string;
   children: string;
   onClick: MouseEventHandler<HTMLAnchorElement>;

--- a/src/components/HeaderSideDrawerListItem/headersidedrawerlistitem.test.tsx
+++ b/src/components/HeaderSideDrawerListItem/headersidedrawerlistitem.test.tsx
@@ -17,11 +17,7 @@ const text = faker.lorem.word();
 describe("HeaderSideDrawerListItem", () => {
   beforeEach(() => {
     render(
-      <HeaderSideDrawerListItem
-        icon={<IconHome />}
-        href={href}
-        onClick={() => {}}
-      >
+      <HeaderSideDrawerListItem icon={IconHome} href={href} onClick={() => {}}>
         {text}
       </HeaderSideDrawerListItem>,
       { wrapper: NextIntlClientWrapper },

--- a/src/components/HomeHero/HomeHero.tsx
+++ b/src/components/HomeHero/HomeHero.tsx
@@ -31,20 +31,12 @@ export default function HomeHero() {
 
       <div className="hidden lg:flex gap-3 z-10 pt-2 xl:pt-8">
         <Link href="/vehicles">
-          <Button
-            endIcon={<IconArrowRight size={16} />}
-            rounded
-            color="primary"
-          >
+          <Button endIcon={IconArrowRight} rounded color="primary">
             {t("hero.browseUsedCars")}
           </Button>
         </Link>
         <Link href="/wheels">
-          <Button
-            endIcon={<IconArrowRight size={16} />}
-            rounded
-            color="primary"
-          >
+          <Button endIcon={IconArrowRight} rounded color="primary">
             {t("hero.browseRimsTires")}
           </Button>
         </Link>

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -25,6 +25,21 @@ export default function IconButton({
     }
   }, []);
 
+  const iconSize = useMemo(() => {
+    switch (size) {
+      case "xs":
+        return 14;
+      case "sm":
+        return 14;
+      case "lg":
+        return 18;
+      default:
+        return 16;
+    }
+  }, []);
+
+  const icon = { children };
+
   return (
     <button
       role="button"
@@ -38,7 +53,7 @@ export default function IconButton({
         className,
       )}
     >
-      {children}
+      <icon.children size={iconSize} />
       {!!badgeCount && (
         <span className="bg-primary dark:bg-primarydark text-white dark:text-black text-xs font-semibold rounded px-1 py-0.5 inline-flex items-center justify-center absolute top-[-5px] right-[-5px] leading-none z-10">
           {badgeCount}

--- a/src/components/IconButton/iconbutton.d.ts
+++ b/src/components/IconButton/iconbutton.d.ts
@@ -1,8 +1,8 @@
-import { ReactElement } from "react";
+import { TablerIcon } from "@tabler/icons-react";
 
 export type IconButtonProps = {
   className?: string;
-  children: ReactElement;
+  children: TablerIcon;
   size?: "xs" | "sm" | "lg";
   isDisabled?: boolean;
   badgeCount?: number;

--- a/src/components/IconButton/iconbutton.test.tsx
+++ b/src/components/IconButton/iconbutton.test.tsx
@@ -12,11 +12,7 @@ describe("IconButton", () => {
   });
 
   it("Renders a button element", () => {
-    render(
-      <IconButton onClick={() => {}}>
-        <IconMenu />
-      </IconButton>,
-    );
+    render(<IconButton onClick={() => {}}>{IconMenu}</IconButton>);
     const button = screen.getByRole("button");
     const type = button.getAttribute("type");
     expect(button).toBeInTheDocument();
@@ -27,7 +23,7 @@ describe("IconButton", () => {
   it("Set the button disabled if provided from props", () => {
     render(
       <IconButton isDisabled onClick={() => {}}>
-        <IconMenu />
+        {IconMenu}
       </IconButton>,
     );
     const button = screen.getByRole("button");
@@ -37,7 +33,7 @@ describe("IconButton", () => {
   it("Renders a badge if a badge count value is passed", () => {
     render(
       <IconButton badgeCount={6} onClick={() => {}}>
-        <IconMenu />
+        {IconMenu}
       </IconButton>,
     );
     const span = screen.getByText(6);

--- a/src/components/ListFilterAside/ListFilterAside.tsx
+++ b/src/components/ListFilterAside/ListFilterAside.tsx
@@ -60,7 +60,7 @@ export default function ListFilterAside({
             <Chip
               key={index}
               iconHref={appliedFilter.deleteHref}
-              rightIcon={<IconX size={16} />}
+              endIcon={IconX}
             >
               {t(
                 `filter.${appliedFilter.paramName}.option.${appliedFilter.paramValue}`,

--- a/src/components/ListFilterHeader/ListFilterHeader.tsx
+++ b/src/components/ListFilterHeader/ListFilterHeader.tsx
@@ -27,7 +27,7 @@ export default function ListFilterHeader({
           className="rounded border border-divider"
           onClick={() => {}}
         >
-          <IconSearch size={16} stroke={2} />
+          {IconSearch}
         </IconButton>
 
         <div className="flex gap-1">
@@ -36,14 +36,14 @@ export default function ListFilterHeader({
             onClick={handleOpenFilterDrawer}
             badgeCount={activeFilterCount}
           >
-            <IconAdjustmentsHorizontal size={16} stroke={1.5} />
+            {IconAdjustmentsHorizontal}
           </IconButton>
           <IconButton
             isDisabled
             className="rounded border border-divider"
             onClick={() => {}}
           >
-            <IconArrowsSort size={16} stroke={1.5} />
+            {IconArrowsSort}
           </IconButton>
         </div>
       </div>

--- a/src/components/SideDrawer/SideDrawer.tsx
+++ b/src/components/SideDrawer/SideDrawer.tsx
@@ -20,7 +20,7 @@ export default function SideDrawer({
         />
         <div className="w-60 bg-background dark:bg-backgrounddark border-l border-l-divider dark:border-l-dividerdark fixed top-0 right-0 h-dvh px-4 py-6 gap-6 flex flex-col overflow-y-scroll">
           <IconButton className="border border-divider" onClick={onClose}>
-            <IconX size={20} stroke={2} />
+            {IconX}
           </IconButton>
 
           {children}

--- a/src/lib/media/MediaList/MediaList.tsx
+++ b/src/lib/media/MediaList/MediaList.tsx
@@ -51,8 +51,9 @@ export default function MediaList({ mediaList, alt }: MediaListProps) {
     [],
   );
 
-  if ((mediaList ?? []).length === 0 || !thumbnail)
+  if ((mediaList ?? []).length === 0 || !thumbnail) {
     return <MediaListSkeleton />;
+  }
 
   return (
     <div className="flex flex-col items-start gap-2 flex-1 @4xl/detailsrightcolumn:flex-row @7xl/detailsrightcolumn:flex-col">

--- a/src/lib/media/MediaList/medialist.test.tsx
+++ b/src/lib/media/MediaList/medialist.test.tsx
@@ -34,6 +34,7 @@ describe("MediaList", () => {
     render(<MediaList mediaList={[]} alt="" />);
     const skeleton = screen.getByTestId("media-skeleton");
     expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toBeVisible();
   });
 
   it("Renders a button with an image within for the thumbnail", () => {

--- a/src/lib/vehicle/VehicleForm/VehicleForm.tsx
+++ b/src/lib/vehicle/VehicleForm/VehicleForm.tsx
@@ -44,10 +44,10 @@ export default function VehicleForm() {
       </div>
 
       <div className="flex flex-col gap-2">
-        <Button color="primary" size="lg" rounded>
+        <Button expanded color="primary" size="lg" rounded>
           {t("checkAvailability")}
         </Button>
-        <Button color="secondary" rounded>
+        <Button expanded color="secondary" rounded>
           {t("scheduleTestDrive")}
         </Button>
       </div>

--- a/src/lib/vehicle/VehicleMediaList/VehicleMediaList.tsx
+++ b/src/lib/vehicle/VehicleMediaList/VehicleMediaList.tsx
@@ -4,7 +4,7 @@ import useVehicleDetails from "@/lib/vehicle/hooks/useVehicleDetails";
 import type { VehicleMediaListProps } from ".";
 
 export default function VehicleMediaList({ vehicle }: VehicleMediaListProps) {
-  if (!vehicle?.medias || vehicle?.medias.length === 0) {
+  if (!vehicle) {
     return null;
   }
   const { titleWithoutYear } = useVehicleDetails(vehicle);

--- a/src/lib/wheel/WheelMediaList/WheelMediaList.tsx
+++ b/src/lib/wheel/WheelMediaList/WheelMediaList.tsx
@@ -4,7 +4,7 @@ import useWheelDetails from "@/lib/wheel/hooks/useWheelDetails";
 import type { WheelMediaListProps } from ".";
 
 export default function WheelMediaList({ wheel }: WheelMediaListProps) {
-  if (!wheel?.medias || wheel?.medias.length === 0) {
+  if (!wheel) {
     return null;
   }
   const { title } = useWheelDetails(wheel);


### PR DESCRIPTION
# Pull request

## Description

> Explain and provide details about all of the changes within your commits

This PR improves the icon usage with better typoing and behavior:

- Imports a proper type from `@tabler/icons-react` replacing generic `ReactNode` or `ReactElement`
- Controls the icon properties (width, stroke width) at the component scale and not from parent

## Preview

> If possible, add screenshots to have a better idea of the rendering

## Checklist

- [ ] My code follows guidelines of the repository
- [ ] I did not detect any bugs when testing my code
- [ ] My changes does not trigger CI error(s)
- [ ] If my changes include new util function(s) or component(s), it is fully documented and easily readable
